### PR TITLE
Add non-release and release workflows

### DIFF
--- a/.github/workflows/ci-cd-non-release.yml
+++ b/.github/workflows/ci-cd-non-release.yml
@@ -1,0 +1,20 @@
+name: "CI/CD (Non-Release)"
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  ci-cd:
+    name: CI/CD
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd-non-release-nodejs.yml@main
+    with:
+      image-repo-name: "nodejs-template"
+      app-name: "nodejs-template"
+    secrets: inherit

--- a/.github/workflows/ci-cd-release.yml
+++ b/.github/workflows/ci-cd-release.yml
@@ -1,0 +1,18 @@
+name: "CI/CD (Release)"
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  ci-cd:
+    name: CI/CD
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/ci-cd-release-nodejs.yml@main
+    with:
+      image-repo-name: "nodejs-template"
+      app-name: "nodejs-template"
+    secrets: inherit


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to streamline the CI/CD process for both non-release and release scenarios. These workflows leverage reusable actions to ensure consistency and efficiency.

### New GitHub Actions Workflows:

* [`.github/workflows/ci-cd-non-release.yml`](diffhunk://#diff-0fa466fa8dddc67484c44df7a6bdfa463120cb83b8e292a09dd3f3cca59ba7bcR1-R20): Added a workflow to handle CI/CD for non-release branches, triggered on pushes to the `main` branch or via manual dispatch. It uses a reusable workflow for Node.js projects and supports concurrency control to prevent overlapping runs.

* [`.github/workflows/ci-cd-release.yml`](diffhunk://#diff-eb916f5872ac32dfa026157008d60d7b1ae37d966de3333b2212d008f2c4ca2cR1-R18): Added a workflow to manage CI/CD for release events, triggered when a release is published. This also uses a reusable workflow for Node.js projects and includes concurrency control.