### PR TITLE
Add PR Checks workflow

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,15 @@
+name: PR checks
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  pr-checks:
+    name: PR format
+    uses: unir-tfm-devops/reusable-github-actions/.github/workflows/pr-checks.yml@main
+    secrets: inherit


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate pull request checks. The workflow triggers on various pull request events and uses a reusable action for PR format validation.

### CI/CD Enhancements:

* [`.github/workflows/pr-checklist.yml`](diffhunk://#diff-4e4b2ad5c6fa82f1766f5db891ba82212b416dd184c4000f4e610a5f05b11c75R1-R15): Introduced a new workflow named "PR checks" that triggers on pull request events (e.g., labeled, unlabeled, opened, edited, synchronize). It uses a reusable GitHub Action from `unir-tfm-devops/reusable-github-actions` to validate PR format and ensures concurrency control by canceling in-progress runs for the same workflow and branch.