### PR TITLE
Update Dockerfile node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the base image in the `Dockerfile` to use a newer version of Node.js.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Changed the Node.js base image from `node:20-alpine` to `node:24-alpine` to ensure compatibility with the latest features and security updates.